### PR TITLE
uses behaviorSubject instead of stream

### DIFF
--- a/lib/src/blocs/bloc.dart
+++ b/lib/src/blocs/bloc.dart
@@ -3,8 +3,8 @@ import 'validators.dart';
 import 'package:rxdart/rxdart.dart';
 
 class Bloc extends Validators {
-  final _emailController = StreamController<String>.broadcast();
-  final _passwordController = StreamController<String>.broadcast();
+  final _emailController = BehaviorSubject<String>();
+  final _passwordController = BehaviorSubject<String>();
 
   //Add data to stream - transform method is attached to the end so all data used by stream is validated.
   Stream<String> get email => _emailController.stream.transform(validateEmail);
@@ -17,6 +17,13 @@ class Bloc extends Validators {
   //Change data
   Function(String) get changeEmail => _emailController.sink.add;
   Function(String) get changePassword => _passwordController.sink.add;
+
+  submit() {
+    final validEmail = _emailController.value;
+    final validPassword = _passwordController.value;
+
+    print('Email is $validEmail. Password is $validPassword');
+  }
 
   //Cleanup
   dispose() {

--- a/lib/src/screens/login_screen.dart
+++ b/lib/src/screens/login_screen.dart
@@ -62,11 +62,7 @@ class LoginScreen extends StatelessWidget {
       builder: (context, snapshot) {
         return ElevatedButton(
           child: const Text('Login'),
-          onPressed: snapshot.hasData
-              ? () {
-                  print('there has been data!');
-                }
-              : null,
+          onPressed: snapshot.hasData ? bloc.submit : null,
         );
       },
     );


### PR DESCRIPTION
By default theres no way to reach back into a stream and get the last value. 
Here we use RxDarts `BehaviourSubject` instead so we can access `.value`
BehaviourSubject is identical to a stream but with added features so theres no need to change anything else in the Bloc

```
class Bloc extends Validators {
  final _emailController = BehaviorSubject<String>();
  final _passwordController = BehaviorSubject<String>();
```

...
```
  submit() {
    final validEmail = _emailController.value;
    final validPassword = _passwordController.value;

    print('Email is $validEmail. Password is $validPassword');
  }
```